### PR TITLE
Fix:下記のバグ修正しました。

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)

--- a/cafe.rb
+++ b/cafe.rb
@@ -31,5 +31,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price] + FOODS[order2][:price]
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -15,11 +15,12 @@ FOODS = [
 ].freeze
 
 def take_order(menus)
-  menus.each.with_index(1) do |menu, i|
+  count_start = 1
+  menus.each.with_index(count_start) do |menu, i|
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i-count_start
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end


### PR DESCRIPTION
下記のバグ修正しました。
- 頼んだつもりのメニューが選択できない。
- お会計額が異様に高い。
- 違う番号のドリンク、フードを注文したとき、お会計が正しくない。

コミットメッセージには残していませんが、以下バグについても本変更で対応完了です。
- 最後の番号のメニューを選択するとエラーとなる。
